### PR TITLE
Add script for universal Linux packaging

### DIFF
--- a/ASAP/annotation/CMakeLists.txt
+++ b/ASAP/annotation/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(AnnotationPlugin SHARED ${ANNOTATION_PLUGIN_SOURCE} ${ANNOTATION_PLU
 
 generate_export_header(AnnotationPlugin)
 target_link_libraries(AnnotationPlugin PUBLIC ASAPLib core PRIVATE multiresolutionimageinterface core annotation Qt6::Core Qt6::Widgets Qt6::UiTools)
-target_compile_definitions(AnnotationPlugin PRIVATE SCRIPTS_DIR="${PROJECT_SOURCE_DIR}/scripts")
+target_compile_definitions(AnnotationPlugin PRIVATE SCRIPTS_DIR="${SCRIPTS_DIR}") # ADDED
 target_include_directories(AnnotationPlugin PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include/ASAP/plugins/workstationextension>)
 set_target_properties(AnnotationPlugin PROPERTIES DEBUG_POSTFIX _d)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ configure_file(
   "${PROJECT_BINARY_DIR}/config/ASAPMacros.h"
 )
 
+set(SCRIPTS_DIR "/usr/share/asap/scripts" CACHE PATH "Directory for ASAP Python scripts") # ADDED
+add_compile_definitions(SCRIPTS_DIR="${SCRIPTS_DIR}") # ADDED
+
 set(CMAKE_MODULE_PATH ${DIAGPathology_SOURCE_DIR}/cmakemodules)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -119,6 +122,8 @@ install(FILES
  
 # Install the export set for use with the install-tree
 install(EXPORT asap-targets DESTINATION cmake)
+
+install(DIRECTORY scripts/ DESTINATION ${SCRIPTS_DIR} FILES_MATCHING PATTERN "*.py") # ADDED
 
 if(PACKAGE_ON_INSTALL)
   set(CPACK_PACKAGE_NAME "ASAP")

--- a/Readme.md
+++ b/Readme.md
@@ -47,6 +47,7 @@ To compile the code yourself, some prerequesites are required. First, we use CMa
 - zlib (http://www.zlib.net/)
 
 To help developers compile this software themselves we provide the necesarry binaries (Visual Studio 2019, 64-bit) for all third party libraries on Windows except OpenCV and Qt (due to size constraints). See the Release page for binaries. If you want to provide the packages yourself, there are no are no strict version requirements, except for libtiff (4.0.1 and higher), Qt (5.1 or higher) and OpenCV (3.1). On Linux all packages can be installed through the package manager on Ubuntu-derived systems (tested on Ubuntu and Kubuntu 18.04 LTS). You can also use the provided Dockerfile for Linux builds (under buildtools).
+An additional helper script `build_universal_package.sh` is available in the `buildtools` directory. It builds a portable TGZ package that can be used on most Linux distributions.
 
 Subsequently, fire up CMake, point it to a source and build directory and hit Configure. Select your compiler of preference and hit ok. This will start the iterative process of CMake trying to find a third party dependency and you specifiying its location. These should be pretty straightforward to fill in (e.g. TIFF\_LIBRRARY should point to tiff.lib, TIFF\_INCLUDE\_DIRECTORY to |folder to libtiff|\include. If more steps are unclear, please open a ticket on the Github issue-tracker.
 

--- a/buildtools/build_universal_package.sh
+++ b/buildtools/build_universal_package.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Build ASAP and produce a universal package for Linux.
+# Usage: build_universal_package.sh [build_gui] [package_type]
+# - build_gui: "true" (default) or "false"
+# - package_type: DEB or TGZ (default TGZ)
+
+build_gui="${1:-true}"
+package_type="${2:-TGZ}"
+
+echo "Building ASAP; build_gui=${build_gui}; package_type=${package_type}"
+
+git clone https://github.com/computationalpathologygroup/ASAP src
+mkdir build
+cd build || exit
+
+cmake_common_args=(
+  -DWRAP_MULTIRESOLUTIONIMAGEINTERFACE_PYTHON=TRUE
+  -DCMAKE_INSTALL_PREFIX=/root/install
+  -DPACKAGE_ON_INSTALL=TRUE
+  -DSWIG_EXECUTABLE=/root/swig/install/bin/swig
+  -DPython3_ROOT_DIR=/root/miniconda3/envs/build
+  -DCPACK_GENERATOR="${package_type}"
+)
+
+if [ "${build_gui}" = "true" ]; then
+  cmake ../src \
+    -DOPENSLIDE_INCLUDE_DIR=/usr/local/include/openslide \
+    -DOpenJPEG_DIR=/root/openjpeg/install/lib/cmake/openjpeg-2.5 \
+    -DBUILD_ASAP=TRUE -DBUILD_EXECUTABLES=TRUE -DBUILD_IMAGEPROCESSING=TRUE \
+    -DCMAKE_BUILD_TYPE=Release -DBUILD_WORKLIST_INTERFACE=TRUE \
+    -DQt6_DIR=/root/qt/6.5.2/gcc_64/lib/cmake/Qt6 \
+    -DQt6GuiTools_DIR=/root/qt/6.5.2/gcc_64/lib/cmake/Qt6GuiTools \
+    "${cmake_common_args[@]}"
+else
+  echo "Skipping GUI..."
+  cmake ../src \
+    -DOPENSLIDE_INCLUDE_DIR=/usr/include/openslide \
+    -DOpenJPEG_DIR=/root/openjpeg/install/lib/cmake/openjpeg-2.5 \
+    -DCMAKE_BUILD_TYPE=Release \
+    "${cmake_common_args[@]}"
+fi
+
+export LD_LIBRARY_PATH=/root/miniconda3/envs/build/lib
+make package
+
+output_ext="tar.gz"
+[ "${package_type}" = "DEB" ] && output_ext="deb"
+
+mkdir -p /artifacts
+for file in *."${output_ext}"; do
+  if [ "${build_gui}" = "true" ]; then
+    cp "$file" "/artifacts/${file%.*}-Linux.${output_ext}"
+  else
+    cp "$file" "/artifacts/${file%.*}-nogui-Linux.${output_ext}"
+  fi
+done


### PR DESCRIPTION
## Summary
- add `build_universal_package.sh` for TGZ or DEB packaging
- document the new helper in Readme
- add configurable `SCRIPTS_DIR` to install and expose Python scripts

## Testing
- `python3 -m py_compile scripts/*.py`
- `shellcheck buildtools/build_universal_package.sh`
- `cmake -S . -B build -DSCRIPTS_DIR=/tmp/asap_scripts -DBUILD_ASAP=OFF -DBUILD_EXECUTABLES=OFF -DBUILD_IMAGEPROCESSING=OFF -DBUILD_TESTS=OFF` *(fails: Could NOT find OPENSLIDE)*

------
https://chatgpt.com/codex/tasks/task_e_688aec591830832fbbfb446745d929d7